### PR TITLE
[+] support for multiple SubjectConfirmation blocks

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -679,7 +679,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
       if (nameID) {
         profile.nameID = nameID[0]._ || nameID[0];
 
-        if (nameID[0].$ && nameID[0].$.Format) {
+        if (nameID[0].$ && nameID[0].$.Format) {c
           profile.nameIDFormat = nameID[0].$.Format;
           profile.nameQualifier = nameID[0].$.NameQualifier;
           profile.spNameQualifier = nameID[0].$.SPNameQualifier;
@@ -692,7 +692,6 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
         for (var i = 0; i < subject[0].SubjectConfirmation.length; i++) {
           var sc = subject[0].SubjectConfirmation[i];
           if (sc.$ && sc.$.Method === 'urn:oasis:names:tc:SAML:2.0:cm:bearer') {
-            console.log('found bearer sc', sc);
             subjectConfirmation = sc;
             break;
           }

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -679,7 +679,7 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
       if (nameID) {
         profile.nameID = nameID[0]._ || nameID[0];
 
-        if (nameID[0].$ && nameID[0].$.Format) {c
+        if (nameID[0].$ && nameID[0].$.Format) {
           profile.nameIDFormat = nameID[0].$.Format;
           profile.nameQualifier = nameID[0].$.NameQualifier;
           profile.spNameQualifier = nameID[0].$.SPNameQualifier;

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -686,14 +686,21 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
         }
       }
 
-      subjectConfirmation = subject[0].SubjectConfirmation ?
-                            subject[0].SubjectConfirmation[0] : null;
+     subjectConfirmation = null;
+
+      if (subject[0].SubjectConfirmation) {
+        for (var i = 0; i < subject[0].SubjectConfirmation.length; i++) {
+          var sc = subject[0].SubjectConfirmation[i];
+          if (sc.$ && sc.$.Method === 'urn:oasis:names:tc:SAML:2.0:cm:bearer') {
+            console.log('found bearer sc', sc);
+            subjectConfirmation = sc;
+            break;
+          }
+        }
+      }
+
       confirmData = subjectConfirmation && subjectConfirmation.SubjectConfirmationData ?
                     subjectConfirmation.SubjectConfirmationData[0] : null;
-      if (subject[0].SubjectConfirmation && subject[0].SubjectConfirmation.length > 1) {
-        msg = 'Unable to process multiple SubjectConfirmations in SAML assertion';
-        throw new Error(msg);
-      }
 
       if (subjectConfirmation) {
         if (confirmData && confirmData.$) {


### PR DESCRIPTION
SAML assertion can have more than one `SubjectConfirmation`, e.g. `urn:oasis:names:tc:SAML:2.0:cm:bearer` and `urn:oasis:names:tc:SAML:2.0:cm:holder-of-key`.
